### PR TITLE
Change cpus limits in docker-compose.minio.yaml

### DIFF
--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -44,7 +44,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "2.5"
+          cpus: "2.0"
           memory: "1024M"
         reservations:
           cpus: "1.5"


### PR DESCRIPTION
## The Issue
Trying to start ddev for the project in GitHub actions, and got this error:

```
Error response from daemon: Range of CPUs is from 0.01 to 2.00, as there are only 2 CPUs available'
```

## How This PR Solves The Issue
Reduces the required number of CPUs to 2.0

## Manual Testing Instructions
N/A
## Automated Testing Overview
N/A

## Related Issue Link(s)
[Is there are some requirements for the runner](https://github.com/ddev/github-action-setup-ddev/issues/36)

## Release/Deployment Notes
N/A