### PR TITLE
chore(*): run update-checker.sh, constraint v1.24.10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.editorconfig export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,19 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-minio/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:
@@ -19,9 +23,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  actions: write
+  contents: read
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -134,4 +134,6 @@ configs:
 
 ## Credits
 
-**Developed and maintained by [Oblak Studio](https://github.com/oblakstudio)**
+**Contributed by [Oblak Studio](https://github.com/oblakstudio)**
+
+**Maintained by the [DDEV team](https://ddev.com/support-ddev/)**

--- a/install.yaml
+++ b/install.yaml
@@ -5,11 +5,10 @@ project_files:
   - commands/minio/mc
   - docker-compose.minio.yaml
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
 
 pre_install_actions:
   - |
-    #ddev-nodisplay
     #ddev-description:Removing old minio files
     has_old_files=false
     for file in "${DDEV_APPROOT}/.ddev/minio/mc-config.json" "${DDEV_APPROOT}/.ddev/.minioImageBuild/Dockerfile" "${DDEV_APPROOT}/.ddev/.minioImageBuild/ddev-entrypoint.sh"; do

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -53,8 +53,14 @@ health_checks() {
 
 teardown() {
   set -eu -o pipefail
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1
+  # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
+  # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    [ -e "${GITHUB_ENV:-}" ] && echo "TESTDIR=${HOME}/tmp/${PROJNAME}" >> "${GITHUB_ENV}"
+  else
+    [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
+  fi
 }
 
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

```bash
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

## How This PR Solves The Issue

- Adds version constraint v1.24.10.
- Updates the add-on files.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-minio/tarball/refs/pull/53/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
