### PR TITLE
feat: remove external_links, add x-ddev for describe and ssh, add hostname, fixes #50

### DIFF
--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -51,8 +51,8 @@ services:
       retries: 1
     x-ddev:
       describe-info: |
-        user: ddevminio
-        pass: ddevminio
+        User: ddevminio
+        Pass: ddevminio
       ssh-shell: bash
 
 configs:

--- a/docker-compose.minio.yaml
+++ b/docker-compose.minio.yaml
@@ -3,6 +3,7 @@ services:
   minio:
     container_name: ddev-${DDEV_SITENAME}-minio
     image: ${MINIO_DOCKER_IMAGE:-minio/minio:latest}
+    hostname: ${DDEV_SITENAME}-minio
     environment:
       MINIO_VOLUMES: "/data"
       MC_CONFIG_DIR: "/root/.mc"
@@ -35,8 +36,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-    external_links:
-      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
     deploy:
       resources:
         limits:
@@ -50,6 +49,11 @@ services:
       interval: 120s
       timeout: 2s
       retries: 1
+    x-ddev:
+      describe-info: |
+        user: ddevminio
+        pass: ddevminio
+      ssh-shell: bash
 
 configs:
   mc-config.json:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,6 +39,15 @@ setup() {
 }
 
 health_checks() {
+  run ddev exec -s minio command -v bash
+  assert_success
+  assert_output --partial "bash"
+
+  run ddev describe
+  assert_success
+  assert_output --partial "user: ddevminio"
+  assert_output --partial "pass: ddevminio"
+
   # Make sure we can hit the 9090 port successfully
   run curl -sfI https://${PROJNAME}.ddev.site:9090
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -45,8 +45,8 @@ health_checks() {
 
   run ddev describe
   assert_success
-  assert_output --partial "user: ddevminio"
-  assert_output --partial "pass: ddevminio"
+  assert_output --partial "User: ddevminio"
+  assert_output --partial "Pass: ddevminio"
 
   # Make sure we can hit the 9090 port successfully
   run curl -sfI https://${PROJNAME}.ddev.site:9090


### PR DESCRIPTION
## The Issue

- Fixes #50

`external_links` are not needed anymore in DDEV v1.24.10

## How This PR Solves The Issue

- Removes `external_links`
- Adds `x-ddev.describe-*` and `x-ddev.ssh-shell`
- Adds `hostname` (for `ddev ssh -s minio`)

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-minio/tarball/refs/pull/54/head
ddev restart
ddev ssh -s minio # see bash
ddev describe # see minio credentials
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
